### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,10 +2,13 @@
 /node_modules
 **/**/node_modules
 .gitignore
-CHANGELOG.md
 
 package-lock.json
 yarn.lock
+
+# Demos
+angular-demo/
+react-demo/
 
 # production
 /build
@@ -13,11 +16,10 @@ yarn.lock
 # src folders
 /circle
 /.circleci
-/mui-icon-builder
 
 # misc
-.DS_Store
-Thumbs.db
+**/**/.DS_Store
+**/**/Thumbs.db
 .env.local
 .env.development.local
 .env.test.local

--- a/angular-demo/package.json
+++ b/angular-demo/package.json
@@ -23,7 +23,7 @@
     "@angular/material": "8.1.3",
     "@angular/platform-browser": "8.2.5",
     "@angular/platform-browser-dynamic": "8.2.5",
-    "@mapbox/mapbox-gl-draw": "1.0.9",
+    "@mapbox/mapbox-gl-draw": "^1.1.2",
     "@mapbox/mapbox-gl-geocoder": "^4.4.1",
     "@pxblue/angular-components": "1.1.1",
     "@pxblue/colors": "1.0.13",

--- a/angular-demo/package.json
+++ b/angular-demo/package.json
@@ -1,5 +1,7 @@
 {
   "name": "pxblue-mapbox-angular",
+  "author": "PX Blue <pxblue@eaton.com>",
+  "license": "BSD-3-Clause",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/angular-demo/yarn.lock
+++ b/angular-demo/yarn.lock
@@ -401,16 +401,16 @@
   resolved "https://registry.yarnpkg.com/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz#ce56e539f83552b58d10d672ea4d6fc9adc7b234"
   integrity sha1-zlblOfg1UrWNENZy6k1vya3HsjQ=
 
-"@mapbox/mapbox-gl-draw@1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.0.9.tgz#ebcb4195d30a7b815b4529033eef0031b6af3024"
-  integrity sha512-33716RoG7BB5MhcQqymPb42TbWrOvTEKbaREby8UHKPerL/50W0z/mt3diX0QYrUsygYJNj5b2lALLWrRJNklw==
+"@mapbox/mapbox-gl-draw@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@mapbox/mapbox-gl-draw/-/mapbox-gl-draw-1.1.2.tgz#247b3f0727db34c2641ab718df5eebeee69a2585"
+  integrity sha512-DWtATUAnJaGZYoH/y2O+QTRybxrp5y3w3eV5FXHFNVcKsCAojKEMB8ALKUG2IsiCKqV/JCAguK9AlPWR7Bjafw==
   dependencies:
     "@mapbox/geojson-area" "^0.2.1"
     "@mapbox/geojson-extent" "^0.3.2"
     "@mapbox/geojson-normalize" "0.0.1"
     "@mapbox/geojsonhint" "^2.0.0"
-    "@mapbox/map-geometry" "0.1.0"
+    "@mapbox/point-geometry" "0.1.0"
     hat "0.0.3"
     lodash.isequal "^4.2.0"
     xtend "^4.0.1"
@@ -464,9 +464,9 @@
   dependencies:
     base-64 "^0.1.0"
 
-"@mapbox/map-geometry@0.1.0", "@mapbox/map-geometry@^0.1.0", "@mapbox/map-geometry@~0.1.0":
+"@mapbox/point-geometry@0.1.0", "@mapbox/point-geometry@^0.1.0", "@mapbox/point-geometry@~0.1.0":
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@mapbox/map-geometry/-/map-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
+  resolved "https://registry.yarnpkg.com/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz#8a83f9335c7860effa2eeeca254332aa0aeed8f2"
   integrity sha1-ioP5M1x4YO/6Lu7KJUMyqgru2PI=
 
 "@mapbox/polyline@^1.0.0":
@@ -491,7 +491,7 @@
   resolved "https://registry.yarnpkg.com/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz#d3a74c90402d06e89ec66de49ec817ff53409666"
   integrity sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==
   dependencies:
-    "@mapbox/map-geometry" "~0.1.0"
+    "@mapbox/point-geometry" "~0.1.0"
 
 "@mapbox/whoots-js@^3.1.0":
   version "3.1.0"
@@ -713,7 +713,7 @@
 
 "@webassemblyjs/floating-point-hex-parser@1.8.5":
   version "1.8.5"
-  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-map-hex-parser/-/floating-map-hex-parser-1.8.5.tgz#1ba926a2923613edce496fd5b02e8ce8a5f49721"
+  resolved "https://registry.yarnpkg.com/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.8.5.tgz#1ba926a2923613edce496fd5b02e8ce8a5f49721"
   integrity sha512-9p+79WHru1oqBh9ewP9zW95E3XAo+90oth7S5Re3eQnECGq59ly1Ri5tsIipKGpiStHsUYmY3zMLqtk3gTcOtQ==
 
 "@webassemblyjs/helper-api-error@1.8.5":
@@ -833,7 +833,7 @@
   integrity sha512-daXC1FyKWHF1i11obK086QRlsMsY4+tIOKgBqI1lxAnkp9xe9YMcgOxm9kLe+ttjs5aWV2KKE1TWJCN57/Btsg==
   dependencies:
     "@webassemblyjs/ast" "1.8.5"
-    "@webassemblyjs/floating-map-hex-parser" "1.8.5"
+    "@webassemblyjs/floating-point-hex-parser" "1.8.5"
     "@webassemblyjs/helper-api-error" "1.8.5"
     "@webassemblyjs/helper-code-frame" "1.8.5"
     "@webassemblyjs/helper-fsm" "1.8.5"
@@ -1959,7 +1959,7 @@ co@^4.6.0:
 
 code-point-at@^1.0.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/code-map-at/-/code-map-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 codelyzer@^5.0.1:
@@ -4065,14 +4065,14 @@ is-finite@^1.0.0:
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-map/-/is-fullwidth-code-map-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
   integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
   dependencies:
     number-is-nan "^1.0.0"
 
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-map/-/is-fullwidth-code-map-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
   integrity sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
 
 is-glob@^3.1.0:
@@ -4911,7 +4911,7 @@ mapbox-gl@^1.3.1:
     "@mapbox/geojson-types" "^1.0.2"
     "@mapbox/jsonlint-lines-primitives" "^2.0.2"
     "@mapbox/mapbox-gl-supported" "^1.4.0"
-    "@mapbox/map-geometry" "^0.1.0"
+    "@mapbox/point-geometry" "^0.1.0"
     "@mapbox/tiny-sdf" "^1.1.0"
     "@mapbox/unitbezier" "^0.0.0"
     "@mapbox/vector-tile" "^1.3.1"
@@ -7333,8 +7333,8 @@ string-width@^1.0.1:
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
   integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
   dependencies:
-    code-map-at "^1.0.0"
-    is-fullwidth-code-map "^1.0.0"
+    code-point-at "^1.0.0"
+    is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
 "string-width@^1.0.2 || 2", string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
@@ -7342,7 +7342,7 @@ string-width@^1.0.1:
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
   dependencies:
-    is-fullwidth-code-map "^2.0.0"
+    is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
 string-width@^3.0.0:
@@ -7351,7 +7351,7 @@ string-width@^3.0.0:
   integrity sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
   dependencies:
     emoji-regex "^7.0.1"
-    is-fullwidth-code-map "^2.0.0"
+    is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
 string.prototype.trimleft@^2.0.0:
@@ -8064,7 +8064,7 @@ vt-pbf@^3.1.1:
   resolved "https://registry.yarnpkg.com/vt-pbf/-/vt-pbf-3.1.1.tgz#b0f627e39a10ce91d943b898ed2363d21899fb82"
   integrity sha512-pHjWdrIoxurpmTcbfBWXaPwSmtPAHS105253P1qyEfSTV2HJddqjM+kIHquaT/L6lVJIk9ltTGc0IxR/G47hYA==
   dependencies:
-    "@mapbox/map-geometry" "0.1.0"
+    "@mapbox/point-geometry" "0.1.0"
     "@mapbox/vector-tile" "^1.3.1"
     pbf "^3.0.5"
 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
   "name": "@pxblue/mapbox",
+  "author": "PX Blue <pxblue@eaton.com>",
+  "license": "BSD-3-Clause",
   "version": "1.0.1",
   "description": "Various Mapbox themes for use in PX Blue applications",
   "main": "index.js",
   "scripts": {
-    "test": "./buildTest.sh"
+    "test": "bash ./buildTest.sh",
+    "link:angular": "bash ./linkAngularMapbox.sh",
+    "start:angular": "cd angular-demo && yarn && cd .. && yarn link:angular && cd angular-demo && yarn start",
+    "link:react": "bash ./linkReactMapbox.sh",
+    "start:react": "cd react-demo && yarn && cd .. && yarn link:react-mapbox && cd react-demo && yarn start" 
   },
   "repository": {
     "type": "git",
@@ -16,8 +22,6 @@
     "PXBlue",
     "Maps"
   ],
-  "author": "pxblue <pxblue@eaton.com>",
-  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/pxblue/mapbox/issues"
   },


### PR DESCRIPTION
Changes proposed in this Pull Request:
- update npmignore to not publish the demo projects
- add author meta data to angular example
- add helper scripts to ./package.json for linking and starting demos