### PR TITLE
Remove old angular react example links

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const map = new mapboxgl.Map({
 });
 ```
 
-For more information on using Mapbox in your application, see our [Mapping Mapbox](https://pxblue.github.io/patterns/visualizations) design page.
+For more information on using Mapbox in your application, see our [visualization](https://pxblue.github.io/patterns/visualizations) design page.
 
 ## Demos
 | Framework           | Live Examples  |

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ const map = new mapboxgl.Map({
     zoom
 });
 ```
-For more detailed instructions on using Mapbox in your application, see our demos for [Angular](https://stackblitz.com/github/pxblue/mapbox/tree/master/angular-demo) or [React](https://codesandbox.io/s/github/pxblue/mapbox/tree/master/react-demo).
+For more detailed instructions on using Mapbox in your application, read about our [Visualization Patterns](https://pxblue.github.io/patterns/visualizations) and see our demos for [Angular](https://stackblitz.com/github/pxblue/mapbox/tree/master/angular-demo) and [React](https://codesandbox.io/s/github/pxblue/mapbox/tree/master/react-demo).
 
 For more information on using Mapbox in your application, see our [visualization](https://pxblue.github.io/patterns/visualizations) design page.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ const map = new mapboxgl.Map({
     zoom
 });
 ```
+For more detailed instructions on using Mapbox in your application, see our demos for [Angular](https://stackblitz.com/github/pxblue/mapbox/tree/master/angular-demo) or [React](https://codesandbox.io/s/github/pxblue/mapbox/tree/master/react-demo).
 
 For more information on using Mapbox in your application, see our [visualization](https://pxblue.github.io/patterns/visualizations) design page.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const map = new mapboxgl.Map({
 });
 ```
 
-For more detailed instructions on using Mapbox in your application, see our demos for [Angular](https://stackblitz.com/edit/pxblue-mapbox-angular) or [React](https://stackblitz.com/edit/pxblue-mapbox-react).
+For more information on using Mapbox in your application, see our [Mapping Mapbox](https://pxblue.github.io/patterns/visualizations) design pattern page.
 
 ## Demos
 | Framework           | Live Examples  |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ const map = new mapboxgl.Map({
 });
 ```
 
-For more information on using Mapbox in your application, see our [Mapping Mapbox](https://pxblue.github.io/patterns/visualizations) design pattern page.
+For more information on using Mapbox in your application, see our [Mapping Mapbox](https://pxblue.github.io/patterns/visualizations) design page.
 
 ## Demos
 | Framework           | Live Examples  |

--- a/README.md
+++ b/README.md
@@ -50,11 +50,6 @@ const map = new mapboxgl.Map({
     zoom
 });
 ```
+
+### More Information
 For more detailed instructions on using Mapbox in your application, read about our [Visualization Patterns](https://pxblue.github.io/patterns/visualizations) and see our demos for [Angular](https://stackblitz.com/github/pxblue/mapbox/tree/master/angular-demo) and [React](https://codesandbox.io/s/github/pxblue/mapbox/tree/master/react-demo).
-
-
-## Demos
-| Framework           | Live Examples  |
-| ---------------- |------------------|
-| Angular | [View on Stackblitz](https://stackblitz.com/github/pxblue/mapbox/tree/master/angular-demo)
-| React | [View on Code Sandbox](https://codesandbox.io/s/github/pxblue/mapbox/tree/master/react-demo)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ const map = new mapboxgl.Map({
 ```
 For more detailed instructions on using Mapbox in your application, read about our [Visualization Patterns](https://pxblue.github.io/patterns/visualizations) and see our demos for [Angular](https://stackblitz.com/github/pxblue/mapbox/tree/master/angular-demo) and [React](https://codesandbox.io/s/github/pxblue/mapbox/tree/master/react-demo).
 
-For more information on using Mapbox in your application, see our [visualization](https://pxblue.github.io/patterns/visualizations) design page.
 
 ## Demos
 | Framework           | Live Examples  |


### PR DESCRIPTION
Fixes old angular/react example links

Changes proposed in this Pull Request:
- Update verbiage for additional info pointed back to visualizations page mapping mapbox page
- 
- 
